### PR TITLE
Sanitize GraphCMS post body HTML

### DIFF
--- a/examples/cms-graphcms/components/post-body.js
+++ b/examples/cms-graphcms/components/post-body.js
@@ -1,10 +1,13 @@
+import sanitizeHtml from "sanitize-html";
 import postStyles from "./post-styles.module.css";
 
 export default function PostBody({ content }) {
+  const sanitizedContent = sanitizeHtml(content?.html ?? "");
+
   return (
     <div
       className={`max-w-2xl mx-auto post ${postStyles.post}`}
-      dangerouslySetInnerHTML={{ __html: content?.html }}
+      dangerouslySetInnerHTML={{ __html: sanitizedContent }}
     />
   );
 }

--- a/examples/cms-graphcms/package.json
+++ b/examples/cms-graphcms/package.json
@@ -10,7 +10,8 @@
     "date-fns": "2.28.0",
     "next": "latest",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "sanitize-html": "2.8.1"
   },
   "devDependencies": {
     "autoprefixer": "10.4.2",


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7493c347-3181-46b2-b993-44e83cfc5680","source":"chat","resourceId":"8d8e4833-4b04-4916-b945-da78f895da1e","workflowId":"2069af1a-5a57-4867-9c55-c8efb9172070","codeChangeId":"2069af1a-5a57-4867-9c55-c8efb9172070","sourceType":"code_security_sast"} -->
### What?

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/475385e680b2ad3c09aebf53824a1ebd?panel_event_id=AwAAAZ8jO-hVxnE0-gAAABhBWjhqTy1oVkFBRGNVVjNoZ21VdDNnRkwAAAAkZjE5ZjIzM2MtOTA5My00ZTYwLTgwMmMtMjRlMzU0ODBhN2RlAABFfQ&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NDc1Mzg1ZTY4MGIyYWQzYzA5YWViZjUzODI0YTFlYmR-OWRhNTU5NWM0ZmJmYWZkYmE4OGY3ZjJiNmNlNGVhYzM%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fnext.js%22+%22Potential+cross-site+scripting%22)

- Sanitized `content?.html` in `examples/cms-graphcms/components/post-body.js` before passing it to `dangerouslySetInnerHTML`.
- Added `sanitize-html` to `examples/cms-graphcms/package.json` so untrusted CMS markup is cleaned before rendering.

### Why?

The post body HTML is fetched from an external CMS and was previously injected directly into the DOM. Without sanitization, malicious markup in CMS content can execute as stored XSS in readers' browsers.

### How?

- Traced data flow from `getPostAndMorePosts` (`content.html`) to `PostBody`.
- Confirmed there was no upstream sanitizer in this example before the sink.
- Attempted format/lint automation, but sandbox networking prevented `pnpm` bootstrap (`registry.npmjs.org` unreachable). Performed manual diff review for this small scoped change.

Closes NEXT-
Fixes #

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/8d8e4833-4b04-4916-b945-da78f895da1e)

Comment @datadog to request changes