### PR TITLE
Harden DatoCMS markdown HTML sanitization

### DIFF
--- a/examples/cms-datocms/lib/markdownToHtml.js
+++ b/examples/cms-datocms/lib/markdownToHtml.js
@@ -2,6 +2,6 @@ import { remark } from "remark";
 import html from "remark-html";
 
 export default async function markdownToHtml(markdown) {
-  const result = await remark().use(html).process(markdown);
+  const result = await remark().use(html, { sanitize: true }).process(markdown);
   return result.toString();
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a98c973e-eeaf-40bb-a12c-bdf993614d28","source":"chat","resourceId":"5c770a72-607c-4c7f-b971-fceb5b54e577","workflowId":"72840e60-df80-4e5a-9431-4f1214aaf0fe","codeChangeId":"72840e60-df80-4e5a-9431-4f1214aaf0fe","sourceType":"code_security_sast"} -->
### What?

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/c0116dc694b34224ecc41c7bed307bab?panel_event_id=AwAAAZ8jKEN9__PQ7QAAABhBWjhqS0VOOUFBQmFIcHpMbU9EZUhKQ2wAAAAkZjE5ZjIzMmUtZDY5MC00Y2M0LWE5MGQtODE5MjZlMWUxMjQ1AAAJng&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22YzAxMTZkYzY5NGIzNDIyNGVjYzQxYzdiZWQzMDdiYWJ-OWRhNTU5NWM0ZmJmYWZkYmE4OGY3ZjJiNmNlNGVhYzM%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fnext.js%22+%22Potential+cross-site+scripting%22)

- Explicitly enable HTML sanitization when converting DatoCMS markdown to HTML in `examples/cms-datocms/lib/markdownToHtml.js`.
- Keep the existing markdown rendering flow while ensuring generated HTML passed to `dangerouslySetInnerHTML` is sanitized.

### Why?

- The post body renders CMS content through `dangerouslySetInnerHTML`, so untrusted markdown content must be sanitized before rendering.
- Making sanitization explicit hardens the example against stored XSS and removes reliance on implicit plugin defaults.

### How?

- Updated the `remark-html` usage to pass `{ sanitize: true }` during markdown processing.
- Validation:
  - `node --check examples/cms-datocms/lib/markdownToHtml.js`
  - `Format` and `Lint` tools were attempted, but failed in this sandbox because `pnpm` could not be downloaded (no network access).

Closes NEXT-
Fixes #

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/5c770a72-607c-4c7f-b971-fceb5b54e577)

Comment @datadog to request changes