### PR TITLE
Sanitize Umbraco post body HTML rendering

### DIFF
--- a/examples/cms-umbraco-heartcore/components/post-body.js
+++ b/examples/cms-umbraco-heartcore/components/post-body.js
@@ -1,10 +1,13 @@
 import postStyles from "./post-styles.module.css";
+import DOMPurify from "isomorphic-dompurify";
 
 export default function PostBody({ content }) {
+  const sanitizedContent = DOMPurify.sanitize(content ?? "");
+
   return (
     <div
       className={`max-w-2xl mx-auto post ${postStyles.post}`}
-      dangerouslySetInnerHTML={{ __html: content }}
+      dangerouslySetInnerHTML={{ __html: sanitizedContent }}
     />
   );
 }

--- a/examples/cms-umbraco-heartcore/package.json
+++ b/examples/cms-umbraco-heartcore/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "classnames": "2.3.1",
     "date-fns": "2.28.0",
+    "isomorphic-dompurify": "^2.0.0",
     "next": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"bc97cebf-5ef7-4b80-8e2c-13cdbc780266","source":"chat","resourceId":"de8e71f0-02eb-4db3-b315-904ba557b89b","workflowId":"7c8d4a98-6bca-41c8-82c5-f84f0118f1ac","codeChangeId":"7c8d4a98-6bca-41c8-82c5-f84f0118f1ac","sourceType":"code_security_sast"} -->
### What?

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/3f72b6e0082f7bdb2a9eb7e61d83227d?panel_event_id=AwAAAZ8jHwin6ZxDGwAAABhBWjhqSHdpbkFBQ1cyWWxGaEtjbHg1dHkAAAAkZjE5ZjIzMjEtMWFhZC00MmViLTkxYTQtMmViNzI4YjQ4NjYzAABi_g&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22M2Y3MmI2ZTAwODJmN2JkYjJhOWViN2U2MWQ4MzIyN2R-OWRhNTU5NWM0ZmJmYWZkYmE4OGY3ZjJiNmNlNGVhYzM%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fnext.js%22+%22Potential+cross-site+scripting%22)

- Sanitize rendered post HTML in the Umbraco Heartcore example before passing it to `dangerouslySetInnerHTML`.
- Add `isomorphic-dompurify` to the example dependencies.

### Why?

- `post.content` comes directly from Umbraco `bodyText` and was previously rendered without sanitization.
- If CMS content is malicious or compromised, this can lead to stored XSS in readers' browsers.
- Sanitization preserves rich-text rendering while removing executable payloads.

### How?

- Traced the data flow from `lib/umbraco-heartcore.js` (`content: bodyText`) through `pages/[...slug].js` into `components/post-body.js`.
- Sanitized `content` with DOMPurify (`isomorphic-dompurify`) and rendered the sanitized result.
- Attempted repo format/lint automation, but the sandbox cannot download pnpm via corepack due restricted network; manually reviewed the focused diff.

Closes NEXT-
Fixes #

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/de8e71f0-02eb-4db3-b315-904ba557b89b)

Comment @datadog to request changes