### PR TITLE
Harden cms-takeshape markdown sanitization

### DIFF
--- a/examples/cms-takeshape/lib/markdownToHtml.js
+++ b/examples/cms-takeshape/lib/markdownToHtml.js
@@ -2,6 +2,6 @@ import { remark } from "remark";
 import html from "remark-html";
 
 export default async function markdownToHtml(markdown) {
-  const result = await remark().use(html).process(markdown);
+  const result = await remark().use(html, { sanitize: true }).process(markdown);
   return result.toString();
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3cfb66ff-bfed-4845-b3c2-eae995c7ba10","source":"chat","resourceId":"ff0b9c02-2dc2-4e01-a8d1-5f21f0a46859","workflowId":"79ecd52e-1bda-43e2-b4e3-b110963cc6b0","codeChangeId":"79ecd52e-1bda-43e2-b4e3-b110963cc6b0","sourceType":"code_security_sast"} -->
### What?

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/7332435e8ad1ebe1d0b81cef605d6eb5?panel_event_id=AwAAAZ8jUj9I192SrwAAABhBWjhqVWo5SUFBRFUtS3pUYXRlUW8wbEIAAAAkZjE5ZjIzNTgtMDc3OC00OGQyLTgxZTgtZDg2ZmM3NzM2ZTFjAAA8ag&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NzMzMjQzNWU4YWQxZWJlMWQwYjgxY2VmNjA1ZDZlYjV-OWRhNTU5NWM0ZmJmYWZkYmE4OGY3ZjJiNmNlNGVhYzM%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fnext.js%22+%22Potential+cross-site+scripting%22)

- Enable explicit HTML sanitization in `examples/cms-takeshape/lib/markdownToHtml.js` by passing `{ sanitize: true }` to `remark-html`.
- Keep the existing markdown-to-HTML rendering flow intact while hardening the security boundary before `dangerouslySetInnerHTML`.

### Why?

- Post content is sourced from an external CMS and ultimately rendered with `dangerouslySetInnerHTML`.
- Making sanitization explicit mitigates potential script injection/XSS payloads in rendered post bodies and documents the intended trust boundary in code.

### How?

- Traced data flow from `getStaticProps` in `pages/posts/[slug].js` through `markdownToHtml` into `PostBody`.
- Updated `remark().use(html)` to `remark().use(html, { sanitize: true })`.
- Validation performed:
  - `node --check examples/cms-takeshape/lib/markdownToHtml.js`
  - Attempted repository formatter/linter tools; they could not run in this sandbox because Corepack tried to fetch pnpm from the internet.

Closes NEXT-
Fixes #

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/ff0b9c02-2dc2-4e01-a8d1-5f21f0a46859)

Comment @datadog to request changes