### PR TITLE
Sanitize Ghost post HTML in cms-ghost example

### DIFF
--- a/examples/cms-ghost/components/post-body.js
+++ b/examples/cms-ghost/components/post-body.js
@@ -1,11 +1,14 @@
 import markdownStyles from "./markdown-styles.module.css";
+import DOMPurify from "isomorphic-dompurify";
 
 export default function PostBody({ content }) {
+  const sanitizedContent = DOMPurify.sanitize(content || "");
+
   return (
     <div className="max-w-2xl mx-auto">
       <div
         className={markdownStyles["markdown"]}
-        dangerouslySetInnerHTML={{ __html: content }}
+        dangerouslySetInnerHTML={{ __html: sanitizedContent }}
       />
     </div>
   );

--- a/examples/cms-ghost/package.json
+++ b/examples/cms-ghost/package.json
@@ -9,6 +9,7 @@
     "@tryghost/content-api": "^1.4.13",
     "classnames": "2.3.1",
     "date-fns": "2.28.0",
+    "isomorphic-dompurify": "^2.0.0",
     "lazysizes": "^5.3.0",
     "next": "latest",
     "react": "^18.2.0",


### PR DESCRIPTION
<!-- dd-meta {"pullId":"7eadbe29-c3bb-4723-9a0a-f1b28d06f391","source":"chat","resourceId":"db32aa75-25e8-4100-90ea-3e8213c9ae49","workflowId":"fbc88ce7-2288-40c4-96b1-91c61fefdd55","codeChangeId":"fbc88ce7-2288-40c4-96b1-91c61fefdd55","sourceType":"code_security_sast"} -->
### What?

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/01a580464005b913261ed1b12d8a726c?panel_event_id=AwAAAZ8jaF4zDq4gUwAAABhBWjhqYUY0ekFBQ1FmZThTZEdYQUJVOGcAAAAkZjE5ZjIzNmItMzkyZC00ZTQ2LTg2MTktYmI5YjBkNzYzNTljAAAHXw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDFhNTgwNDY0MDA1YjkxMzI2MWVkMWIxMmQ4YTcyNmN-OWRhNTU5NWM0ZmJmYWZkYmE4OGY3ZjJiNmNlNGVhYzM%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fnext.js%22+%22Potential+cross-site+scripting%22)

- sanitize Ghost post HTML with isomorphic-dompurify before passing it to dangerouslySetInnerHTML in examples/cms-ghost/components/post-body.js
- add isomorphic-dompurify to examples/cms-ghost/package.json

### Why?
- Datadog SAST reported a high-severity potential XSS in the cms-ghost example because post.html from the Ghost Content API was rendered without an in-repo sanitization step
- this keeps rich post rendering while removing executable markup payloads before they reach the browser

### How?
- ran `node --check examples/cms-ghost/components/post-body.js`
- validated `examples/cms-ghost/package.json` by parsing it with Node
- attempted automated format/lint runs, but the sandbox cannot download pnpm from registry.npmjs.org due offline network constraints

Closes NEXT-
Fixes #

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/db32aa75-25e8-4100-90ea-3e8213c9ae49)

Comment @datadog to request changes